### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.3.1 (unreleased)
+__________________
+
+* Address ``DeprecationWarning`` re: ``collections.abc`` on Python 3.9
+  (`#45 <https://github.com/sloria/tinynetrc/issues/45>`_).
+  Thanks `@tirkarthi <https://github.com/tirkarthi>`_ for the PR.
+
 1.3.0 (2018-12-11)
 ------------------
 

--- a/tinynetrc.py
+++ b/tinynetrc.py
@@ -2,7 +2,12 @@
 """Read and write .netrc files."""
 import netrc
 import os
-from collections import MutableMapping, defaultdict
+from collections import defaultdict
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 __version__ = '1.3.0'
 


### PR DESCRIPTION
Fixes #45 