### PR TITLE
Make password optional while formatting

### DIFF
--- a/tinynetrc.py
+++ b/tinynetrc.py
@@ -96,7 +96,8 @@ class Netrc(MutableMapping):
                                                                  attrs=attrs)
             if attrs[1]:
                 rep += "\taccount {attrs[1]}\n".format(attrs=attrs)
-            rep += "\tpassword {attrs[2]}\n".format(attrs=attrs)
+            if attrs[2]:
+                rep += "\tpassword {attrs[2]}\n".format(attrs=attrs)
         for macro in self._netrc.macros.keys():
             rep += "macdef {macro}\n".format(macro=macro)
             for line in self._netrc.macros[macro]:


### PR DESCRIPTION
If a password is not provided, it's set to the string`None` in the output `.netrc` - it's completely valid to not have a password (for instance, GitHub personal access tokens work this way, only requiring `login`).